### PR TITLE
Value of tabs is not visible in real time

### DIFF
--- a/src/components/templates/default/Edit.jsx
+++ b/src/components/templates/default/Edit.jsx
@@ -83,7 +83,6 @@ const MenuItem = (props) => {
       >
         {editingTab === tab && selected ? (
           <Input
-            fluid
             placeholder={defaultTitle}
             ref={inputRef}
             transparent


### PR DESCRIPTION
When we edit the tab title, the changes are reflected in the right side panel, but not directly in the tab at real time. It’s a little confusing.

### Example

https://user-images.githubusercontent.com/26112509/118830569-59376900-b8bf-11eb-9829-7e61c4744abb.mov

This happens because the fluid class limits the width of the input.
![fluid class](https://user-images.githubusercontent.com/26112509/118832496-f515a480-b8c0-11eb-8aea-26187b70ef1d.png)

To improve it, I removed the fluid attribute from the input. [Reference](https://github.com/eea/volto-tabs-block/compare/master...codesyntax:tab-edit-input?expand=1#diff-e33c9acb7685ac11eadecf4e1376154b1ffe7908a2cac067bec62a2666cf3019L86)


### Result

https://user-images.githubusercontent.com/26112509/118833484-c21fe080-b8c1-11eb-8049-d096298ae0ae.mov



