### PR TITLE
(Fix): check if schema.properties.data exists

### DIFF
--- a/src/components/templates/accordion/Edit.jsx
+++ b/src/components/templates/accordion/Edit.jsx
@@ -117,7 +117,7 @@ const Edit = (props) => {
                       ...(newFormData.blocks_layout.items.length > 0
                         ? newFormData
                         : emptyTab({
-                            schema: schema.properties.data.schema,
+                            schema: schema?.properties?.data?.schema || {},
                             intl,
                           })),
                     },

--- a/src/components/templates/default/Edit.jsx
+++ b/src/components/templates/default/Edit.jsx
@@ -59,7 +59,7 @@ export const MenuItem = (props) => {
           ...tabsData.blocks,
           [tabId]: {
             ...emptyTab({
-              schema: schema.properties.data.schema,
+              schema: schema?.properties?.data?.schema || {},
               intl,
             }),
           },
@@ -267,7 +267,7 @@ const Edit = (props) => {
                         ...(newFormData.blocks_layout.items.length > 0
                           ? newFormData
                           : emptyTab({
-                              schema: schema.properties.data.schema,
+                              schema: schema?.properties?.data?.schema || {},
                               intl,
                             })),
                       },


### PR DESCRIPTION
If you edit a tabs block in a controlpanel/dexterity-types/<content_type>/layout an error will come:
<img width="1680" alt="Captură de ecran din 2023-12-04 la 12 00 37" src="https://github.com/eea/volto-tabs-block/assets/50819975/1c2f1736-e212-4aa4-9ad8-b4976a29c034">
