### PR TITLE
Fix order tab bug.

### DIFF
--- a/src/components/variations/default/Edit.jsx
+++ b/src/components/variations/default/Edit.jsx
@@ -248,6 +248,7 @@ const Edit = (props) => {
               allowedBlocks={data?.allowedBlocks}
               description={data?.instructions?.data}
               manage={manage}
+              isMainForm={false}
               metadata={metadata}
               pathname={props.pathname}
               properties={isEmpty(tabs[tab]) ? emptyBlocksForm() : tabs[tab]}

--- a/src/components/variations/horizontal-responsive/Edit.jsx
+++ b/src/components/variations/horizontal-responsive/Edit.jsx
@@ -351,6 +351,7 @@ const Edit = (props) => {
               allowedBlocks={data?.allowedBlocks}
               description={data?.instructions?.data}
               manage={manage}
+              isMainForm={false}
               metadata={metadata}
               pathname={props.pathname}
               properties={isEmpty(tabs[tab]) ? emptyBlocksForm() : tabs[tab]}


### PR DESCRIPTION
Because the BlocksForm will sync with the global form state by default the order tab (and other functionality which uses the global form state) will break. This change fixes that problem.